### PR TITLE
Remove removal of :tags= - doesn't work unless I remove this

### DIFF
--- a/lib/puppet/provider/aws_iam_role/api.rb
+++ b/lib/puppet/provider/aws_iam_role/api.rb
@@ -2,7 +2,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'pu
 
 Puppet::Type.type(:aws_iam_role).provide(:api, :parent => Puppet_X::Bobtfish::Ec2_api) do
   mk_resource_methods
-  remove_method :tags= # We want the method inherited from the parent
 
   def self.new_from_aws(item)
     new(


### PR DESCRIPTION
I'm not sure what this line of code does, or is supposed to do, but unless I remove it the aws_iam_role resource type doesn't work:

```
$ bundle exec puppet resource aws_iam_role --libdir lib
Error: Could not autoload puppet/provider/aws_iam_role/api: method `tags=' not defined in Puppet::Type::Aws_iam_role::ProviderApi
Error: Could not autoload puppet/type/aws_iam_role: Could not autoload puppet/provider/aws_iam_role/api: method `tags=' not defined in Puppet::Type::Aws_iam_role::ProviderApi
Error: Could not run: Could not autoload puppet/type/aws_iam_role: Could not autoload puppet/provider/aws_iam_role/api: method `tags=' not defined in Puppet::Type::Aws_iam_role::ProviderApi
```
